### PR TITLE
Remove pointer in variables for svcLauncher

### DIFF
--- a/cmd/gosvc/main.go
+++ b/cmd/gosvc/main.go
@@ -22,7 +22,7 @@ var sha1ver string
 
 func svcLauncher() error {
 
-	err := app.Run(&elog, svcName, sha1ver)
+	err := app.Run(elog, svcName, sha1ver)
 	if err != nil {
 		return errors.Wrap(err, "app.run")
 	}


### PR DESCRIPTION
This was causing the following error
cannot use &elog (type *debug.Log) as type debug.Log in argument to app.Run:
        *debug.Log is pointer to interface, not interface